### PR TITLE
remove roi_selector from socket timeout message

### DIFF
--- a/src/screenshare/__init__.py
+++ b/src/screenshare/__init__.py
@@ -335,7 +335,7 @@ def main():
                     exit()
                 except socket.timeout as ex:
                     cv2.destroyAllWindows()
-                    print('socket timeout', roi_selector.x_min, roi_selector.x_max, roi_selector.y_min, roi_selector.y_max)
+                    print('socket timeout')
                 except Exception as ex:
                     cv2.destroyAllWindows()
                     print(ex)


### PR DESCRIPTION
Hi!
If p1 or p2 are None the Properties (x_min, y_min, ...) of the ROISelector cause an Execption. Therefore i removed them from the socket timeout message.